### PR TITLE
SAR 242: Code generating script and README instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Any valuesets that are listed in CQL files and are NOT commented out are using a
 ## Generating ValueSet Codes from NCQA Measurements.
 As of September 2021, we received measurements from NCQA that came with ValueSet codes. To generate these codes quickly, use the following command in this repo:
 `node code-generator.js --dir=<directory that contains the files> --name=<output name of .js>`
-The script will then generate the needed codes for you. The created file will be in the same directory you indicated, so be sure to move it to `/data/codes` after checking there are no issues.
+The script will then generate the needed codes for you. The created file will be in the same directory you indicated, so be sure to move it to `/data/codes` after checking there are no issues and run a test there.
 
 # CQL Execution Framework
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ CQL files that require medication codes are don't include all of the necessary c
 ## Using VSAC URNs instead of the HEDIS specified URNs (Updated: 3/16/2021)
 Any valuesets that are listed in CQL files and are NOT commented out are using a valueset URN (and therefore a list of codes in the `data/codes` directory) from VSAC; Long term, we want to be using the valueset URNs (and therefore codes associated with those URNs) from the valuesets listed in the HEDIS excel sheet that a few of us have licesnses to; however, we can't currently grab data from that excel sheet (programmatically or otherwise) due to some licensing issues. However,  Mike is a part of a HEDIS user group and thinks he may have access to the excel sheet, but hasn't looked into it yet.
 
+## Generating ValueSet Codes from NCQA Measurements.
+As of September 2021, we received measurements from NCQA that came with ValueSet codes. To generate these codes quickly, use the following command in this repo:
+`node code-generator.js --dir=<directory that contains the files> --name=<output name of .js>`
+The script will then generate the needed codes for you. The created file will be in the same directory you indicated, so be sure to move it to `/data/codes` after checking there are no issues.
+
 # CQL Execution Framework
 
 The CQL Execution Framework provides a JavaScript library for executing CQL artifacts expressed as

--- a/code-generator.js
+++ b/code-generator.js
@@ -22,6 +22,7 @@ fs.readdir(parseArgs['dir'], function(readErr, files) {
     console.error('\x1b[31m', 
       '\tError: Unable to scan directory:' + readErr + '.',
       '\x1b[0m');
+    process.exit();
   }
 
   files.forEach(file => {
@@ -61,7 +62,9 @@ fs.readdir(parseArgs['dir'], function(readErr, files) {
       console.log('\tNote: Using identifier for oidKey.');
       oidKey = jsonFile.identifier[0].value;
     } else {
-      console.log('\tNote: Using filename for oidKey.');
+      console.warn('\x1b[33m',
+        '\tNote: Using filename for oidKey.',
+        '\x1b[0m');
       oidKey = file.slice(0,-5);
     }
 

--- a/code-generator.js
+++ b/code-generator.js
@@ -1,0 +1,89 @@
+/* eslint-disable no-console */
+
+const parseArgs = require('minimist')(process.argv.slice(2));
+const fs = require('fs');
+const path = require('path');
+
+if(parseArgs['dir'] === undefined) {
+  console.log('Please define a directory path to read. Usage: "--dir=<directory>".');
+  process.exit();
+}
+
+if(parseArgs['name'] === undefined) {
+  console.log('Please define a name to output the file. The .js will be applied automatically. Usage: "--name=<codefile name>".');
+  process.exit();
+}
+
+let codes = {};
+const noTitle='No Title Found';
+let noTitleNum = 0;
+fs.readdir(parseArgs['dir'], function(readErr, files) {
+  if (readErr) {
+    console.error('\x1b[31m', 
+      '\tError: Unable to scan directory:' + readErr + '.',
+      '\x1b[0m');
+  }
+
+  files.forEach(file => {
+    console.log('\nProcessing ' + file + '...');
+
+    if(!file.endsWith('.json')) {
+      console.log('\tNote: Skipping ' + file + ' as it is not a .json file.');
+      return;
+    }
+
+    let jsonFile = JSON.parse(fs.readFileSync(path.join(parseArgs['dir'], file)));
+    if (!jsonFile.expansion || !jsonFile.expansion.contains) {
+      console.error('\x1b[31m', 
+        '\tError: No "expansion.contains" found. Skipping file but please investigate.',
+        '\x1b[0m');
+      return;
+    }
+
+    const contains = jsonFile.expansion.contains.map(container => {
+      delete container.display;
+      return container;
+    });
+
+    let title;
+    if (jsonFile.title) {
+      title=jsonFile.title;
+    } else {
+      console.warn('\x1b[33m', 
+        '\tWarning: No "title" was found. Please manually update. Continuing with temp title "' + noTitle + noTitleNum + '".',
+        '\x1b[0m');
+      title = noTitle + noTitleNum;
+      noTitleNum++;
+    }
+    
+    let oidKey;
+    if (jsonFile.identifier && jsonFile.identifier[0].value) {
+      console.log('\tNote: Using identifier for oidKey.');
+      oidKey = jsonFile.identifier[0].value;
+    } else {
+      console.log('\tNote: Using filename for oidKey.');
+      oidKey = file.slice(0,-5);
+    }
+
+    codes[oidKey] = {
+      [title]: contains
+    };
+  });
+
+  const outputPath = path.join(parseArgs['dir'], parseArgs['name'] + '.js');
+  console.log('\tProcessing of files complete. Saving to: ' + outputPath);
+  const jsonOutput = 'const codes = ' + 
+    JSON.stringify(codes, null, 2).replace(/"(\w+)"\s*:/g, '$1:').replace(/"/g,'\'') +
+      ';\nmodule.exports = codes;';
+
+  try {
+    fs.writeFileSync(outputPath, jsonOutput);
+  } catch (writeErr) {
+    console.error('\x1b[31m', 
+      '\tError: Unable to write to directory:' + writeErr + '.',
+      '\x1b[0m');
+  }
+  console.log('\x1b[32m', 
+    '\tSuccess: Please check the created file and update to export "const codes" of the created object.',
+    '\x1b[0m');
+});

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "express-actuator": "^1.7.1",
     "joi": "^17.4.0",
     "jsonl": "^1.1.2",
+    "minimist": "^1.2.5",
     "moment": "^2.27.0",
     "node-watch": "^0.7.1",
     "ucum": "^0.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3079,6 +3079,15 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+express-actuator@^1.7.1:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/express-actuator/-/express-actuator-1.8.0.tgz#a3929e1203f4629ce14929164cda1c63d01ea387"
+  integrity sha512-2pgqB2lSvE79lxPCWwe+Fn4lQ7QBMZKOe1HTuZPFv8k46oXUBSttFr1y8Y77fyDsC/hr4ER41dCbdpqnolX1Ig==
+  dependencies:
+    express "^4.17.1"
+    moment "^2.29.1"
+    properties-reader "^2.2.0"
+
 express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.npmjs.org/express/-/express-4.17.1.tgz"
@@ -4300,6 +4309,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 mocha@^8.4.0:
   version "8.4.0"
   resolved "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz"
@@ -4356,6 +4370,11 @@ moment@^2.27.0:
   version "2.27.0"
   resolved "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz"
   integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
+
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 ms@2.0.0:
   version "2.0.0"
@@ -4759,6 +4778,13 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+properties-reader@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/properties-reader/-/properties-reader-2.2.0.tgz#41d837fe143d8d5f2386b6a869a1975c0b2c595c"
+  integrity sha512-CgVcr8MwGoBKK24r9TwHfZkLLaNFHQ6y4wgT9w/XzdpacOOi5ciH4hcuLechSDAwXsfrGQtI2JTutY2djOx2Ow==
+  dependencies:
+    mkdirp "^1.0.4"
 
 proxy-addr@~2.0.5:
   version "2.0.6"


### PR DESCRIPTION
This NodeJS script will generate codes from the NCQA Measurement ValueSets. 

Instructions:

1. Extract your measurements from the zips and place them somewhere. Note the directory.
2. In the repo, run `yarn` as you will need the new `minimist` library. This library simplifies CLI commands.
3. Run the following CLI command, `node code-generator.js --dir=<to the valueset directory you extracted to> --name=<name of what you want the file to be>`

So for example, mine would be node code-generator.js --dir=C:\Users\James\workspaces\ncqa-hedis\DRRE_HEDIS_MY2022-1.0.0\valuesets --name=depression-remission-codes-2022`.

4. Check the output. The code should skip any non-json files (so you can rerun it), it should throw warnings and errors if the `title` is not found or if the `extension.contains` is empty, but it should skip over any issues. Also @hmayenve and @anthem123 please check that it runs fine on Macs. I used `path` to avoid any OS directory collisions. Also, check if there are any color issues on your OS' shell. 
5. Verify the results look good. You can then drag them into the repo and drop them in `data/codes`.