### PR TITLE
Feature/sar 314 DMS-E

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 <!-- If there is no Jira ticket for this PR, say why not. -->
 
-- [SAR-###](https://jira.amida-tech.com/browse/SAR-###)
+- [SAR-###](https://amida.atlassian.net/browse/SAR-###)
 
 # Other Repos' PR(s) Intended to Work With This PR
 

--- a/data/patients/dmse/dmse-2022-adult-patient-1.json
+++ b/data/patients/dmse/dmse-2022-adult-patient-1.json
@@ -1,0 +1,679 @@
+[
+  {
+    "resourceType": "Bundle",
+    "id": "adult-depression-bundle",
+    "type": "transaction",
+    "entry": [
+      {
+        "resource": {
+          "resourceType": "Patient",
+          "id": "patient-1",
+          "meta": {
+            "profile": [
+              "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+            ]
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+              "extension": [
+                {
+                  "url": "ombCategory",
+                  "valueCoding": {
+                    "system": "urn:oid:2.16.840.1.113883.6.238",
+                    "code": "2054-5",
+                    "display": "Black or African American"
+                  }
+                }
+              ]
+            },
+            {
+              "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+              "extension": [
+                {
+                  "url": "ombCategory",
+                  "valueCoding": {
+                    "system": "urn:oid:2.16.840.1.113883.6.238",
+                    "code": "2186-5",
+                    "display": "Not Hispanic or Latino"
+                  }
+                }
+              ]
+            }
+          ],
+          "identifier": [
+            {
+              "use": "usual",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "MR",
+                    "display": "Medical Record Number"
+                  }
+                ]
+              },
+              "system": "http://hospital.smarthealthit.org",
+              "value": "999999993"
+            }
+          ],
+          "name": [
+            {
+              "family": "Doe",
+              "given": [
+                "Jill"
+              ]
+            }
+          ],
+          "gender": "female",
+          "birthDate": "2000-07-29"
+        },
+        "request": {
+          "method": "PUT",
+          "url": "Patient/patient-1"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:coverage-1",
+        "resource": {
+          "resourceType": "Coverage",
+          "id": "coverage-1",
+          "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A human-readable rendering of the coverage</div>"
+          },
+          "identifier": [
+            {
+              "system": "http://benefitsinc.com/certificate",
+              "value": "12345"
+            }
+          ],
+          "status": "active",
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                "code": "RETIRE",
+                "display": "retiree health program"
+              },
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                "code": "DRUGPOL",
+                "display": "Drug Policy"
+              }
+            ]
+          },
+          "policyHolder": {
+            "reference": "http://benefitsinc.com/FHIR/Organization/CBI35"
+          },
+          "subscriber": {
+            "reference": "Patient/patient-1"
+          },
+          "beneficiary": {
+            "reference": "Patient/patient-1"
+          },
+          "dependent": "0",
+          "relationship": {
+            "coding": [
+              {
+                "code": "self"
+              }
+            ]
+          },
+          "period": {
+            "start": "2022-01-01",
+            "end": "2022-12-31"
+          },
+          "payor": [
+            {
+              "reference": "Organization/2"
+            }
+          ],
+          "class": [
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "group"
+                  }
+                ]
+              },
+              "value": "CB135",
+              "name": "Corporate Baker's Inc. Local #35"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "subgroup"
+                  }
+                ]
+              },
+              "value": "123",
+              "name": "Trainee Part-time Benefits"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "plan"
+                  }
+                ]
+              },
+              "value": "B37FC",
+              "name": "Full Coverage: Medical, Dental, Pharmacy, Vision, EHC"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "subplan"
+                  }
+                ]
+              },
+              "value": "P7",
+              "name": "Includes afterlife benefits"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "class"
+                  }
+                ]
+              },
+              "value": "SILVER",
+              "name": "Silver: Family Plan spouse only"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "subclass"
+                  }
+                ]
+              },
+              "value": "Tier2",
+              "name": "Low deductable, max $20 copay"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "sequence"
+                  }
+                ]
+              },
+              "value": "9"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "rxid"
+                  }
+                ]
+              },
+              "value": "MDF12345"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "rxbin"
+                  }
+                ]
+              },
+              "value": "987654"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "rxgroup"
+                  }
+                ]
+              },
+              "value": "M35PT"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "rxpcn"
+                  }
+                ]
+              },
+              "value": "234516"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "sequence"
+                  }
+                ]
+              },
+              "value": "9"
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:observation-1",
+        "resource": {
+          "resourceType": "Observation",
+          "id": "observation-1",
+          "text": {
+            "status": "generated"
+          },
+          "status": "final",
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                  "code": "therapy",
+                  "display": "Therapy"
+                }
+              ]
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "320751009",
+                "display": "63412003"
+              }
+            ]
+          },
+          "subject": {
+            "reference": "Patient/patient-1"
+          },
+          "encounter": {
+            "reference": "Encounter/encounter-1"
+          },
+          "effectiveDateTime": "2022-03-01",
+          "valueInteger": 10
+        },
+        "request": {
+          "method": "POST",
+          "url": "Observation"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:observation-2",
+        "resource": {
+          "resourceType": "Observation",
+          "id": "observation-2",
+          "text": {
+            "status": "generated"
+          },
+          "status": "final",
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                  "code": "therapy",
+                  "display": "Therapy"
+                }
+              ]
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "44261-6",
+                "display": "Patient Health Questionnaire 9 item (PHQ-9) total score [Reported]"
+              }
+            ]
+          },
+          "subject": {
+            "reference": "Patient/patient-1"
+          },
+          "encounter": {
+            "reference": "Encounter/encounter-1"
+          },
+          "effectiveDateTime": "2022-03-28",
+          "valueInteger": 200
+        },
+        "request": {
+          "method": "POST",
+          "url": "Observation"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:encounter-1",
+        "resource": {
+          "resourceType": "Encounter",
+          "meta": {
+            "profile": [
+              "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"
+            ]
+          },
+          "id": "encounter-1",
+          "status": "finished",
+          "class": {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+            "code": "AMB"
+          },
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "https://www.nubc.org/CodeSystem/RevenueCodes",
+                  "version": "2012.05",
+                  "code": "0904",
+                  "display": "Activity therapy"
+                }
+              ],
+              "text": "Activity therapy"
+            }
+          ],
+          "diagnosis": [
+            {
+              "condition": {
+                "reference": "Condition/condition-1",
+                "display": "The patient has major depression"
+              },
+              "rank": 1
+            }
+          ],
+          "subject": {
+            "reference": "urn:uuid:96dcbd62-e4c6-a555-a663-77d08ad3c3b5",
+            "display": "Mr. Young120 Murphy561"
+          },
+          "period": {
+            "start": "2022-01-12T19:57:22-04:00",
+            "end": "2022-02-01T20:12:22-04:00"
+          },
+          "serviceProvider": {
+            "reference": "urn:uuid:275e5209-84ff-3ee7-bf02-d0e979877861",
+            "display": "LEXINGTON EYE ASSOCIATES, INC"
+          }
+        },
+        "request": {
+          "method": "POST",
+          "url": "Encounter"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:condition-1",
+        "resource": {
+          "resourceType": "Condition",
+          "id": "condition-1",
+          "identifier": [
+            {
+              "value": "12345"
+            }
+          ],
+          "clinicalStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active"
+              }
+            ]
+          },
+          "verificationStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed"
+              }
+            ]
+          },
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "320751009",
+                  "display": "Major depression, melancholic type"
+                }
+              ]
+            }
+          ],
+          "severity": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "255604002",
+                "display": "Mild"
+              }
+            ]
+          },
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                  "code": "320751009",
+                  "display": "Major depression, melancholic type"
+              }
+            ]
+          },
+          "bodySite": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "38266002",
+                  "display": "Entire body as a whole"
+                }
+              ]
+            }
+          ],
+          "subject": {
+            "reference": "Patient/patient-1",
+            "display": "Roel"
+          },
+          "encounter": {
+            "reference": "encounter-1"
+          },
+          "onsetDateTime": "2022-01-12",
+          "abatementDateTime": "2022-02-09",
+          "recordedDate": "2022-01-12",
+          "recorder": {
+            "reference": "Practitioner/f201"
+          },
+          "asserter": {
+            "reference": "Practitioner/f201"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:condition-2",
+        "resource": {
+          "resourceType": "Condition",
+          "id": "condition-2",
+          "identifier": [
+            {
+              "value": "12345"
+            }
+          ],
+          "clinicalStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active"
+              }
+            ]
+          },
+          "verificationStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed"
+              }
+            ]
+          },
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "55607006",
+                  "display": "Problem"
+                },
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                  "code": "problem-list-item"
+                }
+              ]
+            }
+          ],
+          "severity": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "255604002",
+                "display": "Mild"
+              }
+            ]
+          },
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "2021.03.20AB",
+                "code": "192080009",
+                "display": "Chronic depression"
+              }
+            ]
+          },
+          "bodySite": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "38266002",
+                  "display": "Entire body as a whole"
+                }
+              ]
+            }
+          ],
+          "subject": {
+            "reference": "Patient/patient-1",
+            "display": "Roel"
+          },
+          "encounter": {
+            "reference": "encounter-1"
+          },
+          "onsetDateTime": "2021-04-02",
+          "abatementDateTime": "2021-04-09",
+          "recordedDate": "2021-04-02",
+          "recorder": {
+            "reference": "Practitioner/f201"
+          },
+          "asserter": {
+            "reference": "Practitioner/f201"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:condition-3",
+        "resource": {
+          "resourceType": "Condition",
+          "id": "condition-3",
+          "identifier": [
+            {
+              "value": "12345"
+            }
+          ],
+          "clinicalStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active"
+              }
+            ]
+          },
+          "verificationStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed"
+              }
+            ]
+          },
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "55607006",
+                  "display": "Problem"
+                },
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                  "code": "problem-list-item"
+                }
+              ]
+            }
+          ],
+          "severity": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "255604002",
+                "display": "Mild"
+              }
+            ]
+          },
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "2021.03.20AB",
+                "code": "191692007",
+                "display": "Active disintegrative psychoses"
+              }
+            ]
+          },
+          "bodySite": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "38266002",
+                  "display": "Entire body as a whole"
+                }
+              ]
+            }
+          ],
+          "subject": {
+            "reference": "Patient/patient-1",
+            "display": "Roel"
+          },
+          "encounter": {
+            "reference": "encounter-1"
+          },
+          "onsetDateTime": "2021-04-02",
+          "abatementDateTime": "2021-04-09",
+          "recordedDate": "2021-04-02",
+          "recorder": {
+            "reference": "Practitioner/f201"
+          },
+          "asserter": {
+            "reference": "Practitioner/f201"
+          }
+        }
+      }
+    ]
+  }
+]

--- a/data/patients/dmse/dmse-2022-adult-patient-1.json
+++ b/data/patients/dmse/dmse-2022-adult-patient-1.json
@@ -395,16 +395,114 @@
             }
           ],
           "subject": {
-            "reference": "urn:uuid:96dcbd62-e4c6-a555-a663-77d08ad3c3b5",
-            "display": "Mr. Young120 Murphy561"
+            "reference": "Patient/patient-1",
+            "display": "Jill Doe"
           },
           "period": {
             "start": "2022-01-12T19:57:22-04:00",
             "end": "2022-02-01T20:12:22-04:00"
+          }
+        },
+        "request": {
+          "method": "POST",
+          "url": "Encounter"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:encounter-2",
+        "resource": {
+          "resourceType": "Encounter",
+          "meta": {
+            "profile": [
+              "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"
+            ]
           },
-          "serviceProvider": {
-            "reference": "urn:uuid:275e5209-84ff-3ee7-bf02-d0e979877861",
-            "display": "LEXINGTON EYE ASSOCIATES, INC"
+          "id": "encounter-2",
+          "status": "finished",
+          "class": {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+            "code": "AMB"
+          },
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "https://www.nubc.org/CodeSystem/RevenueCodes",
+                  "version": "2012.05",
+                  "code": "0904",
+                  "display": "Activity therapy"
+                }
+              ],
+              "text": "Activity therapy"
+            }
+          ],
+          "diagnosis": [
+            {
+              "condition": {
+                "reference": "Condition/condition-2",
+                "display": "The patient has major depression"
+              },
+              "rank": 1
+            }
+          ],
+          "subject": {
+            "reference": "Patient/patient-1",
+            "display": "Jill Doe"
+          },
+          "period": {
+            "start": "2022-06-12T19:57:22-04:00",
+            "end": "2022-07-01T20:12:22-04:700"
+          }
+        },
+        "request": {
+          "method": "POST",
+          "url": "Encounter"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:encounter-3",
+        "resource": {
+          "resourceType": "Encounter",
+          "meta": {
+            "profile": [
+              "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"
+            ]
+          },
+          "id": "encounter-3",
+          "status": "finished",
+          "class": {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+            "code": "AMB"
+          },
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "https://www.nubc.org/CodeSystem/RevenueCodes",
+                  "version": "2012.05",
+                  "code": "0904",
+                  "display": "Activity therapy"
+                }
+              ],
+              "text": "Activity therapy"
+            }
+          ],
+          "diagnosis": [
+            {
+              "condition": {
+                "reference": "Condition/condition-3",
+                "display": "The patient has major depression"
+              },
+              "rank": 1
+            }
+          ],
+          "subject": {
+            "reference": "Patient/patient-1",
+            "display": "Jill Doe"
+          },
+          "period": {
+            "start": "2022-09-02T19:57:22-04:00",
+            "end": "2022-10-09T20:12:22-04:700"
           }
         },
         "request": {
@@ -467,20 +565,9 @@
               }
             ]
           },
-          "bodySite": [
-            {
-              "coding": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "38266002",
-                  "display": "Entire body as a whole"
-                }
-              ]
-            }
-          ],
           "subject": {
             "reference": "Patient/patient-1",
-            "display": "Roel"
+            "display": "Jill Doe"
           },
           "encounter": {
             "reference": "encounter-1"
@@ -503,7 +590,7 @@
           "id": "condition-2",
           "identifier": [
             {
-              "value": "12345"
+              "value": "88888"
             }
           ],
           "clinicalStatus": {
@@ -527,12 +614,8 @@
               "coding": [
                 {
                   "system": "http://snomed.info/sct",
-                  "code": "55607006",
-                  "display": "Problem"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/condition-category",
-                  "code": "problem-list-item"
+                  "code": "320751009",
+                  "display": "Major depression, melancholic type"
                 }
               ]
             }
@@ -550,33 +633,21 @@
             "coding": [
               {
                 "system": "http://snomed.info/sct",
-                "version": "2021.03.20AB",
-                "code": "192080009",
-                "display": "Chronic depression"
+                  "code": "14183003",
+                  "display": "Chronic major depressive disorder, single episode"
               }
             ]
           },
-          "bodySite": [
-            {
-              "coding": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "38266002",
-                  "display": "Entire body as a whole"
-                }
-              ]
-            }
-          ],
           "subject": {
             "reference": "Patient/patient-1",
-            "display": "Roel"
+            "display": "Jill Doe"
           },
           "encounter": {
-            "reference": "encounter-1"
+            "reference": "encounter-2"
           },
-          "onsetDateTime": "2021-04-02",
-          "abatementDateTime": "2021-04-09",
-          "recordedDate": "2021-04-02",
+          "onsetDateTime": "2022-06-12",
+          "abatementDateTime": "2022-07-01",
+          "recordedDate": "2022-06-12",
           "recorder": {
             "reference": "Practitioner/f201"
           },
@@ -640,32 +711,21 @@
               {
                 "system": "http://snomed.info/sct",
                 "version": "2021.03.20AB",
-                "code": "191692007",
-                "display": "Active disintegrative psychoses"
+                "code": "78667006",
+                "display": "Dysthymia"
               }
             ]
           },
-          "bodySite": [
-            {
-              "coding": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "38266002",
-                  "display": "Entire body as a whole"
-                }
-              ]
-            }
-          ],
           "subject": {
             "reference": "Patient/patient-1",
-            "display": "Roel"
+            "display": "Jill Doe"
           },
           "encounter": {
-            "reference": "encounter-1"
+            "reference": "encounter-3"
           },
-          "onsetDateTime": "2021-04-02",
-          "abatementDateTime": "2021-04-09",
-          "recordedDate": "2021-04-02",
+          "onsetDateTime": "2021-09-02",
+          "abatementDateTime": "2021-10-09",
+          "recordedDate": "2021-09-02",
           "recorder": {
             "reference": "Practitioner/f201"
           },

--- a/data/patients/dmse/dmse-2022-adult-patient-1.json
+++ b/data/patients/dmse/dmse-2022-adult-patient-1.json
@@ -766,9 +766,399 @@
           "encounter": {
             "reference": "encounter-3"
           },
-          "onsetDateTime": "2021-09-02",
-          "abatementDateTime": "2021-10-09",
-          "recordedDate": "2021-09-02",
+          "onsetDateTime": "2022-09-02",
+          "abatementDateTime": "2022-10-09",
+          "recordedDate": "2022-09-02",
+          "recorder": {
+            "reference": "Practitioner/f201"
+          },
+          "asserter": {
+            "reference": "Practitioner/f201"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:condition-bipolar",
+        "resource": {
+          "resourceType": "Condition",
+          "id": "condition-bipolar",
+          "identifier": [
+            {
+              "value": "888"
+            }
+          ],
+          "clinicalStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active"
+              }
+            ]
+          },
+          "verificationStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed"
+              }
+            ]
+          },
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "55607006",
+                  "display": "Problem"
+                },
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                  "code": "problem-list-item"
+                }
+              ]
+            }
+          ],
+          "severity": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "255604002",
+                "display": "Mild"
+              }
+            ]
+          },
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "2021.03.20AB",
+                "code": "191627008",
+                "display": "Bipolar affective disorder, current episode depression"
+              }
+            ]
+          },
+          "subject": {
+            "reference": "Patient/patient-1",
+            "display": "Jill Doe"
+          },
+          "encounter": {
+            "reference": "Encounter/encounter-1"
+          },
+          "onsetDateTime": "2022-01-12",
+          "abatementDateTime": "2022-02-01",
+          "recordedDate": "2022-01-12",
+          "recorder": {
+            "reference": "Practitioner/f201"
+          },
+          "asserter": {
+            "reference": "Practitioner/f201"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:condition-other-bipolar",
+        "resource": {
+          "resourceType": "Condition",
+          "id": "condition-other-bipolar",
+          "identifier": [
+            {
+              "value": "889"
+            }
+          ],
+          "clinicalStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active"
+              }
+            ]
+          },
+          "verificationStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed"
+              }
+            ]
+          },
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "55607006",
+                  "display": "Problem"
+                },
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                  "code": "problem-list-item"
+                }
+              ]
+            }
+          ],
+          "severity": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "255604002",
+                "display": "Mild"
+              }
+            ]
+          },
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "2021.03.20AB",
+                "code": "16295005",
+                "display": "Bipolar II disorder, most recent episode major depressive"
+              }
+            ]
+          },
+          "subject": {
+            "reference": "Patient/patient-1",
+            "display": "Jill Doe"
+          },
+          "encounter": {
+            "reference": "Encounter/encounter-1"
+          },
+          "onsetDateTime": "2022-01-12",
+          "abatementDateTime": "2022-02-01",
+          "recordedDate": "2022-01-12",
+          "recorder": {
+            "reference": "Practitioner/f201"
+          },
+          "asserter": {
+            "reference": "Practitioner/f201"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:condition-personality-disorder",
+        "resource": {
+          "resourceType": "Condition",
+          "id": "condition-personality-disorder",
+          "identifier": [
+            {
+              "value": "890"
+            }
+          ],
+          "clinicalStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active"
+              }
+            ]
+          },
+          "verificationStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed"
+              }
+            ]
+          },
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "55607006",
+                  "display": "Problem"
+                },
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                  "code": "problem-list-item"
+                }
+              ]
+            }
+          ],
+          "severity": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "255604002",
+                "display": "Mild"
+              }
+            ]
+          },
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "2021.03.20AB",
+                "code": "231527003",
+                "display": "Explosive personality disorder"
+              }
+            ]
+          },
+          "subject": {
+            "reference": "Patient/patient-1",
+            "display": "Jill Doe"
+          },
+          "encounter": {
+            "reference": "Encounter/encounter-1"
+          },
+          "onsetDateTime": "2022-01-12",
+          "abatementDateTime": "2022-02-01",
+          "recordedDate": "2022-01-12",
+          "recorder": {
+            "reference": "Practitioner/f201"
+          },
+          "asserter": {
+            "reference": "Practitioner/f201"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:condition-pervasive-development-disorder",
+        "resource": {
+          "resourceType": "Condition",
+          "id": "condition-pervasive-development-disorder",
+          "identifier": [
+            {
+              "value": "891"
+            }
+          ],
+          "clinicalStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active"
+              }
+            ]
+          },
+          "verificationStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed"
+              }
+            ]
+          },
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "55607006",
+                  "display": "Problem"
+                },
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                  "code": "problem-list-item"
+                }
+              ]
+            }
+          ],
+          "severity": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "255604002",
+                "display": "Mild"
+              }
+            ]
+          },
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "2021.03.20AB",
+                "code": "231536004",
+                "display": "Atypical autism"
+              }
+            ]
+          },
+          "subject": {
+            "reference": "Patient/patient-1",
+            "display": "Jill Doe"
+          },
+          "encounter": {
+            "reference": "Encounter/encounter-1"
+          },
+          "onsetDateTime": "2022-01-12",
+          "abatementDateTime": "2022-02-01",
+          "recordedDate": "2022-01-12",
+          "recorder": {
+            "reference": "Practitioner/f201"
+          },
+          "asserter": {
+            "reference": "Practitioner/f201"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:condition-psychotic-disorder",
+        "resource": {
+          "resourceType": "Condition",
+          "id": "condition-psychotic-disorder",
+          "identifier": [
+            {
+              "value": "892"
+            }
+          ],
+          "clinicalStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active"
+              }
+            ]
+          },
+          "verificationStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed"
+              }
+            ]
+          },
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "55607006",
+                  "display": "Problem"
+                },
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                  "code": "problem-list-item"
+                }
+              ]
+            }
+          ],
+          "severity": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "255604002",
+                "display": "Mild"
+              }
+            ]
+          },
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "2021.03.20AB",
+                "code": "278853003",
+                "display": "Acute schizophrenia-like psychotic disorder"
+              }
+            ]
+          },
+          "subject": {
+            "reference": "Patient/patient-1",
+            "display": "Jill Doe"
+          },
+          "encounter": {
+            "reference": "Encounter/encounter-1"
+          },
+          "onsetDateTime": "2022-01-12",
+          "abatementDateTime": "2022-02-01",
+          "recordedDate": "2022-01-12",
           "recorder": {
             "reference": "Practitioner/f201"
           },

--- a/data/patients/dmse/dmse-2022-adult-patient-1.json
+++ b/data/patients/dmse/dmse-2022-adult-patient-1.json
@@ -66,7 +66,7 @@
             }
           ],
           "gender": "female",
-          "birthDate": "2000-07-29"
+          "birthDate": "2004-04-29"
         },
         "request": {
           "method": "PUT",
@@ -294,9 +294,9 @@
           "code": {
             "coding": [
               {
-                "system": "http://snomed.info/sct",
-                "code": "320751009",
-                "display": "63412003"
+                "system": "http://loinc.org",
+                "code": "89204-2",
+                "display": "Patient Health Questionnaire-9: Modified for Teens total score [Reported.PHQ.Teen]"
               }
             ]
           },
@@ -306,7 +306,7 @@
           "encounter": {
             "reference": "Encounter/encounter-1"
           },
-          "effectiveDateTime": "2022-03-01",
+          "effectiveDateTime": "2022-01-12",
           "valueInteger": 10
         },
         "request": {
@@ -347,9 +347,52 @@
             "reference": "Patient/patient-1"
           },
           "encounter": {
-            "reference": "Encounter/encounter-1"
+            "reference": "Encounter/encounter-2"
           },
-          "effectiveDateTime": "2022-03-28",
+          "effectiveDateTime": "2022-06-12",
+          "valueInteger": 200
+        },
+        "request": {
+          "method": "POST",
+          "url": "Observation"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:observation-3",
+        "resource": {
+          "resourceType": "Observation",
+          "id": "observation-3",
+          "text": {
+            "status": "generated"
+          },
+          "status": "final",
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                  "code": "therapy",
+                  "display": "Therapy"
+                }
+              ]
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "44261-6",
+                "display": "Patient Health Questionnaire 9 item (PHQ-9) total score [Reported]"
+              }
+            ]
+          },
+          "subject": {
+            "reference": "Patient/patient-1"
+          },
+          "encounter": {
+            "reference": "Encounter/encounter-3"
+          },
+          "effectiveDateTime": "2022-09-02",
           "valueInteger": 200
         },
         "request": {


### PR DESCRIPTION
# Related Tickets

- [SAR-314](https://jira.amida-tech.com/browse/SAR-314)

DMS-E measures signs of depression remissions. It is broken into three areas, covering different months over the measurement year. January through April is numerator and denominator 1, May through August is 2 and the rest is 3.

- The denominators are controlled by `Encounters` that have `Conditions` of major depression or dysthymia. 
- The numerators are conditions in which someone scored on a PHQ-9 (a Patient Health Questionnaire 9 that checks for depression), called a "PHQ-9 Assessment With A Score Documented." There are also considerations for "PHQ-9 Modified for Teens" but these results will also be found in the "Score Documented." The scores can be found under the `Observation` objects.
- Exclusions occur for anyone who has one of two groupings of bipolar disorder, or personality, psychotic or pervasive development disorder. Having any one of these earns an exclusion, but I've included all five for the sake of completeness. These are `Conditions` with IDs the same as the conditions in question, such as "condition-psychotic-disorder." If any of them are found at any time **during the measurement year**, the patient merits an exclusion. You can find them all on the bottom.

Environmental variables to test:
`MEASUREMENT_FILE=private\DMSE_HEDIS_MY2022-1.0.0\elm\DMSE_HEDIS_MY2022-1.0.0.json`
`LIBRARIES_DIRECTORY=private\DMSE_HEDIS_MY2022-1.0.0\libraryElm\`
`VALUESETS_DIRECTORY=private\DMSE_HEDIS_MY2022-1.0.0\valuesets\`
`MEASUREMENT_DEV_DATA=data\patients\dmse`

1. [ ] This PR passes all automated tests.
2. [ ] This PR has no linting errors.
3. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
   <!--- Such as moving to a new branch on an API, modifying a table, running a script, etc. -->
   <!--- If yes, please document the changes here. -->