### PR TITLE
Bug/sar 432 aab uri fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,10 +336,10 @@ For AAB, CWP and URI, the following process can rewrite the CQL to be faster. Th
 Do not move the CQL file from its location in the private folder. It also checks value set files the neighboring folders. When finished, it will inform you of the created script and its location.
 
 Copy this file into the libraryCql folder neighboring the cql folder. To run the cql-to-elm transformation, navigate to the following folder inside the `clinical_quality_language` repo:
-`clinical_quality_language\Src\java\cql-to-elm\build\install\cql-to-elm\bin>cql-to-elm`
+`clinical_quality_language\Src\java\cql-to-elm\build\install\cql-to-elm\bin`
 
 Then run this CLI command, changing the folders to your local spots:
-`cql-to-elm --format=JSON --input saraswati-cql-execution\private\1.1.0\AAB_HEDIS_MY2022-1.0.0\libraryCql\Amida_AAB_HEDIS_MY2022-1.1.0.cql --output saraswati-cql-execution\private\1.1.0\AAB_HEDIS_MY2022-1.1.0\elm\Amida_AAB_HEDIS_MY2022-1.1.0.json`
+`cql-to-elm --format=JSON --compatibility-level=1.4 --input saraswati-cql-execution\private\1.1.0\AAB_HEDIS_MY2022-1.0.0\libraryCql\Amida_AAB_HEDIS_MY2022-1.1.0.cql --output saraswati-cql-execution\private\1.1.0\AAB_HEDIS_MY2022-1.1.0\elm\Amida_AAB_HEDIS_MY2022-1.1.0.json`
 
 Finally, in saraswati-cql-execution, change the `.env` features to this:
 

--- a/data/patients/aab/bronchitis-patient-1.json
+++ b/data/patients/aab/bronchitis-patient-1.json
@@ -1,4 +1,4 @@
-[
+[ 
   {
     "resourceType": "Bundle",
     "type": "transaction",
@@ -523,7 +523,7 @@
         "fullUrl": "urn:uuid:aab-prof-claim",
         "resource": {
           "resourceType": "Claim",
-          "id": "urn:uuid:aab-prof-claim",
+          "id": "aab-prof-claim",
           "identifier": [
             {
               "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
@@ -800,6 +800,74 @@
         "request": {
           "method": "POST",
           "url": "Immunization"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:psa-claimResponse",
+        "resource": {
+          "resourceType": "ClaimResponse",
+          "id": "psa-claimResponse",
+          "status": "active",
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+                "code": "pharmacy"
+              }
+            ]
+          },
+          "use": "claim",
+          "patient": {
+            "reference": "urn:uuid:aab-patient-1"
+          },
+          "created": "2021-08-16",
+          "outcome": "complete",
+          "disposition": "Claim settled as per contract.",
+          "request": {
+            "reference": "Claim/urn:uuid:aab-pharm-claim-1"
+          },
+          "item": [
+            {
+              "itemSequence": 1,
+              "servicedPeriod": {
+                "start": "2021-08-16",
+                "end": "2021-08-17"
+              },
+              "adjudication": [
+                {
+                  "category": {
+                    "coding": [
+                      {
+                        "code": "benefit"
+                      }
+                    ]
+                  },
+                  "amount": {
+                    "value": 108.45, 
+                    "currency": "USD"
+                  }
+                }
+              ]
+            }
+          ],
+          "addItem": [
+            {
+              "productOrService": {
+                "coding": [
+                  {
+                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                    "version": "2021.03.01.20AB",
+                    "code": "242816",
+                    "display": "100 ML gentamicin 1 MG/ML Injection"
+                  }
+                ]
+              },
+              "servicedPeriod": {
+                "start": "2021-08-16",
+                "end": "2021-08-17"
+              }
+            }
+          ]
         }
       },
       {

--- a/data/patients/uri/uri-patient-1.json
+++ b/data/patients/uri/uri-patient-1.json
@@ -543,7 +543,7 @@
           "patient": {
             "reference": "urn:uuid:uri-patient-1"
           },
-          "created": "2014-08-16",
+          "created": "2022-02-16",
           "priority": {
             "coding": [
               {
@@ -623,7 +623,7 @@
           "patient": {
             "reference": "urn:uuid:uri-patient-1"
           },
-          "created": "2022-02-16",
+          "created": "2022-02-17",
           "priority": {
             "coding": [
               {
@@ -639,14 +639,14 @@
                   {
                     "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
                     "version": "2021.03.01.20AB",
-                    "code": "1747115",
-                    "display": "50 ML cefotaxime 20 MG/ML Injection"
+                    "code": "242816",
+                    "display": "100 ML gentamicin 1 MG/ML Injection"
                   }
                 ]
               },
               "servicedPeriod": {
-                "start": "2022-02-16T10:30:10+01:00",
-                "end": "2022-02-17T10:31:10+01:00"
+                "start": "2022-02-17T10:30:10+01:00",
+                "end": "2022-02-18T10:31:10+01:00"
               },
               "unitPrice": {
                 "value": 135.57,
@@ -662,6 +662,74 @@
         "request": {
           "method": "POST",
           "url": "Immunization"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:psa-claimResponse",
+        "resource": {
+          "resourceType": "ClaimResponse",
+          "id": "psa-claimResponse",
+          "status": "active",
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+                "code": "pharmacy"
+              }
+            ]
+          },
+          "use": "claim",
+          "patient": {
+            "reference": "urn:uuid:uri-patient-1"
+          },
+          "created": "2022-02-17",
+          "outcome": "complete",
+          "disposition": "Claim settled as per contract.",
+          "request": {
+            "reference": "Claim/uri-claim-2"
+          },
+          "item": [
+            {
+              "itemSequence": 1,
+              "servicedPeriod": {
+                "start": "2022-02-17",
+                "end": "2022-02-18"
+              },
+              "adjudication": [
+                {
+                  "category": {
+                    "coding": [
+                      {
+                        "code": "benefit"
+                      }
+                    ]
+                  },
+                  "amount": {
+                    "value": 108.45, 
+                    "currency": "USD"
+                  }
+                }
+              ]
+            }
+          ],
+          "addItem": [
+            {
+              "productOrService": {
+                "coding": [
+                  {
+                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                    "version": "2021.03.01.20AB",
+                    "code": "242816",
+                    "display": "100 ML gentamicin 1 MG/ML Injection"
+                  }
+                ]
+              },
+              "servicedPeriod": { 
+                "start": "2022-02-16",
+                "end": "2022-02-17"
+              }
+            }
+          ]
         }
       },
       {


### PR DESCRIPTION
Long story short, due to changes in the CQL, we need both `Claims` and `ClaimResponses` to cover antibiotic uses. The mentioned antibiotics have to be within certain dates (a year of the measurement period and within 3 days of the infection), have a code for Pharmacy, reference each other (ie, a `Claim` must have a matching `ClaimResponse`) and the antibiotic codes have to match. Anyway, these are returning numerators now. 

Check the `README.md` update for how to generate the Amida CQL valuesets and run CQL-to-ELM transformations. 